### PR TITLE
Fix bug on rotation ?

### DIFF
--- a/Drinks/src/main/java/fr/masciulli/drinks/fragment/DrinkDetailFragment.java
+++ b/Drinks/src/main/java/fr/masciulli/drinks/fragment/DrinkDetailFragment.java
@@ -10,7 +10,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -23,6 +22,7 @@ import android.view.animation.DecelerateInterpolator;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.squareup.picasso.Picasso;
@@ -208,10 +208,15 @@ public class DrinkDetailFragment extends Fragment implements ScrollViewListener,
         }
         mBlurredImageView.setAlpha(alpha);
 
-        mImageView.setTop((0 - y) / 2);
-        mImageView.setBottom(mImageViewHeight - y);
-        mBlurredImageView.setTop((0 - y) / 2);
-        mBlurredImageView.setBottom(mImageViewHeight - y);
+        RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) mImageView.getLayoutParams();
+        params.setMargins(params.leftMargin, -y, params.rightMargin, params.bottomMargin);
+        mImageView.setLayoutParams(params);
+        mImageView.setPadding(mImageView.getPaddingLeft(), y / 2, mImageView.getPaddingRight(), mImageView.getPaddingBottom());
+
+        params = (RelativeLayout.LayoutParams) mBlurredImageView.getLayoutParams();
+        params.setMargins(params.leftMargin, -y, params.rightMargin, params.bottomMargin);
+        mBlurredImageView.setLayoutParams(params);
+        mBlurredImageView.setPadding(mImageView.getPaddingLeft(), y / 2, mImageView.getPaddingRight(), mImageView.getPaddingBottom());
     }
 
     @Override
@@ -254,7 +259,8 @@ public class DrinkDetailFragment extends Fragment implements ScrollViewListener,
                     mScrollView.animate().setDuration(ANIM_TEXT_ENTER_DURATION).
                             alpha(1).
                             setInterpolator(sDecelerator);
-
+                    // Fake a onScrollChangedCall to apply changes to mBlurredImageView and mImageView.
+                    fakeOnScrollChanged();
                     return true;
                 }
             });
@@ -299,6 +305,11 @@ public class DrinkDetailFragment extends Fragment implements ScrollViewListener,
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void fakeOnScrollChanged() {
+        onScrollChanged(mScrollView, mScrollView.getScrollX(),
+                mScrollView.getScrollY(), mScrollView.getScrollX(), mScrollView.getScrollY());
     }
 
     private class QuantizeBitmapTask extends AsyncTask<Bitmap, Void, ArrayList<Integer>> {


### PR DESCRIPTION
An attempt to fixe the issue https://github.com/amasciul/Drinks/issues/42

I call manually the onScrollChanged during the onPreDraw so that the scrollView.getScrollY() returns the correct value and not 0, but for some reasons that I don't know the bottom and top are modified after that.

So I try to find a work around to avoid using setBottom and setTop that are "meant to be called by the layout" according to the doccumentation.

```
Sets the bottom position of this view relative to its parent. This method is meant to be called by the layout system and should not generally be called otherwise, because the property may be changed at any time by the layout.
```

At the end, my solution relies on paddings and margins, that might not be very elegant but it seems to work as intended =) 

Let me know what you think !
