### PR TITLE
Improve contrast ratio of toolbar buttons

### DIFF
--- a/app/src/main/res/drawable/scrim_top.xml
+++ b/app/src/main/res/drawable/scrim_top.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:startColor="@color/black_transparent"
+        android:centerColor="@android:color/transparent"
+        android:endColor="@android:color/transparent"/>
+</shape>

--- a/app/src/main/res/layout/activity_drink.xml
+++ b/app/src/main/res/layout/activity_drink.xml
@@ -10,7 +10,7 @@
 
         <android.support.design.widget.CollapsingToolbarLayout
             android:layout_width="match_parent"
-            android:layout_height="192dp"
+            android:layout_height="@dimen/collapsing_toolbar_height"
             app:contentScrim="?attr/colorPrimary"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
@@ -23,6 +23,12 @@
                 android:transitionName="@string/transition_drink"
                 app:layout_collapseMode="parallax"
                 tools:targetApi="lollipop" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/top_scrim_height"
+                android:background="@drawable/scrim_top"
+                app:layout_collapseMode="pin" />
 
             <View
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_liquor.xml
+++ b/app/src/main/res/layout/activity_liquor.xml
@@ -10,7 +10,7 @@
 
         <android.support.design.widget.CollapsingToolbarLayout
             android:layout_width="match_parent"
-            android:layout_height="192dp"
+            android:layout_height="@dimen/collapsing_toolbar_height"
             app:contentScrim="?attr/colorPrimary"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
@@ -23,6 +23,12 @@
                 android:transitionName="@string/transition_liquor"
                 app:layout_collapseMode="parallax"
                 tools:targetApi="lollipop" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/top_scrim_height"
+                android:background="@drawable/scrim_top"
+                app:layout_collapseMode="pin" />
 
             <View
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="top_scrim_height">110dp</dimen>
+    <dimen name="collapsing_toolbar_height">192dp</dimen>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Currently, the buttons in the toolbar in the drink and liquor activities are not visible for some photos, 
since they are white buttons on a white background.

I've added a scrim at the top of the CollapsingToolbarLayouts in activity_drink and activity_liquor to make the buttons more visible.